### PR TITLE
Fix: timer

### DIFF
--- a/src/Categories.js
+++ b/src/Categories.js
@@ -1,19 +1,30 @@
-import { useParams, useNavigate } from "react-router-dom";
-import { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { useState, useEffect, useCallback } from "react";
 
-function Categories({setViewCurr, setViewNext}) {
-    const navigate = useNavigate();
+function Categories({viewCurr, setViewCurr, setViewNext}) {
     const { roomId } = useParams();
     const [categories, setCategories] = useState([{category: "Animals"}, {category: "Objects"}, {category: "Buildings"}]);
-    const [counter, setCounter] = useState(60)
-    const [timer, setTimer] = useState("0:00")
+    const [counter, setCounter] = useState(60);
+    /* FOR TESTING COMMENT OUT ABOVE LINE, UNCOMMENT BELOW LINE */
+    // const [counter, setCounter] = useState(10);
+    const [timer, setTimer] = useState("0:00");
+
+    const handleNextBtn = useCallback (() => {
+        setViewNext(true);
+        setViewCurr(false);
+        setCounter(60);
+        /* FOR TESTING COMMENT OUT ABOVE LINE, UNCOMMENT BELOW LINE */
+        // setCounter(10);
+    }, [setViewCurr, setViewNext, setCounter]);
 
     useEffect(() => {
         const intervalId = setInterval(() => {
-            setCounter(counter => counter - 1)
+            if (viewCurr) {
+                setCounter(counter => counter - 1)
+            }
         }, 1000);
         return () => clearInterval(intervalId);
-    }, []);
+    }, [viewCurr, setCounter]);
 
     useEffect(() => {
         setTimer(() => {
@@ -24,18 +35,14 @@ function Categories({setViewCurr, setViewNext}) {
             }
             return (minutes + ":0" + seconds);
         });
-    });
+    }, [counter, setTimer]);
 
     //placeholder until votes can be sent to the backend
-    if(counter <= 0){
-        // navigate(`/drawing/${roomId}`);
-        handleNextBtn();
-    }
-
-    function handleNextBtn() {
-        setViewCurr(false);
-        setViewNext(true);
-    }
+    useEffect(() => {
+        if (counter <= 0) {
+            handleNextBtn();
+        }
+    }, [counter, viewCurr, handleNextBtn]);
 
     return (
         <div className="background custom-text">

--- a/src/Drawing.js
+++ b/src/Drawing.js
@@ -1,22 +1,26 @@
 import { useParams } from "react-router-dom";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 
-function Drawing({setViewCurr, setViewNext}){
+function Drawing({viewCurr, setViewCurr, setViewNext}){
     const { roomId } = useParams();
     const [artist, setArtist] = useState("user_3");
     const [tricksters, setTricksters] = useState(["user_1", "user_2", "user_4", "user_5", "user_6", "user_7", "user_8", "user_9"]);
     const [category, setCategory] = useState({category: "Animals"});
-    const [view, setView] = useState(true)
-    const [counter, setCounter] = useState(180)
-    const [timer, setTimer] = useState("0:00")
+    const [view, setView] = useState(true);
+    const [counter, setCounter] = useState(180);
+    /* FOR TESTING COMMENT OUT ABOVE LINE, UNCOMMENT BELOW LINE */
+    // const [counter, setCounter] = useState(10);
+    const [timer, setTimer] = useState("0:00");
     const [canvas, setCanvas] = useState(<canvas className="m-auto size-5/6 bg-white"></canvas>)
 
     useEffect(() => {
         const intervalId = setInterval(() => {
-            setCounter(counter => counter - 1)
+            if (viewCurr) {
+                setCounter(counter => counter - 1);
+            }
         }, 1000);
         return () => clearInterval(intervalId);
-    }, []);
+    }, [viewCurr, setCounter]);
 
     useEffect(() => {
         setTimer(() => {
@@ -27,7 +31,7 @@ function Drawing({setViewCurr, setViewNext}){
             }
             return (minutes + ":0" + seconds);
         });
-    });
+    }, [counter, setTimer]);
 
     //temporary function to test both views at once
     function swapView() {
@@ -37,14 +41,20 @@ function Drawing({setViewCurr, setViewNext}){
     }
 
     //placeholder until the drawing can actually be sent to the backend
-    function submitDrawing(){
+    const submitDrawing = useCallback(() => {
         // navigate(`/voting/${roomId}`);
-        setViewCurr(false);
         setViewNext(true);
-    }
-    if(counter <= 0){
-        submitDrawing();
-    }
+        setViewCurr(false);
+        setCounter(180);
+        /* FOR TESTING COMMENT OUT ABOVE LINE, UNCOMMENT BELOW LINE */
+        // setCounter(10);
+    }, [setViewCurr, setViewNext, setCounter]);
+
+    useEffect(() => {
+        if(counter <= 0){
+            submitDrawing();
+        }
+    }, [counter, viewCurr, submitDrawing]);
 
     //placeholder until messages can be sent between clients
     function sendMessage(){}

--- a/src/Lobby.js
+++ b/src/Lobby.js
@@ -55,11 +55,15 @@ function Lobby({setViewCurr, setViewNext, socket, setSocket, isHost, setIsHost, 
     // Emit startGame event if current user is the host
     if (isHost) {
       socket.emit('startGame', roomId);
-      setViewCurr(false);
-      setViewNext(true);
+      handleNext();
     } else {
       alert('Only the host can start the game.');
     }
+  }
+
+  function handleNext() {
+    setViewCurr(false);
+    setViewNext(true);
   }
 
     //procedurally generate table/list for users 

--- a/src/Room.js
+++ b/src/Room.js
@@ -24,12 +24,11 @@ function Room() {
     const [viewScoreboard, setViewScoreboard] = useState(false);
 
     return (
-        // we have to wrap each component into a div with an ID so other components can find the ID and hide/show modals depending on game state
         <div>
             {viewLobby && <Lobby socket={socket} setSocket={setSocket} isHost={isHost} setIsHost={setIsHost} guestName={guestName} setViewCurr={setViewLobby} setViewNext={setViewCategories} />}
-            {viewCategories && <Categories setViewCurr={setViewCategories} setViewNext={setViewDrawing} />}
-            {viewDrawing && <Drawing setViewCurr={setViewDrawing} setViewNext={setViewVoting} />}
-            {viewVoting && <Voting setViewCurr={setViewVoting} setViewNext={setViewResults} /> }
+            {viewCategories && <Categories viewCurr={viewCategories} setViewCurr={setViewCategories} setViewNext={setViewDrawing} />}
+            {viewDrawing && <Drawing viewCurr={viewDrawing} setViewCurr={setViewDrawing} setViewNext={setViewVoting} />}
+            {viewVoting && <Voting viewCurr={viewVoting} setViewCurr={setViewVoting} setViewNext={setViewResults} /> }
             {viewResults && <Results setViewCurr={setViewResults} setViewNext={setViewScoreboard} /> }
             {viewScoreboard && <Scoreboard setViewCurr={setViewScoreboard} setViewNext={setViewCategories} /> }
         </div>

--- a/src/Voting.js
+++ b/src/Voting.js
@@ -1,24 +1,30 @@
-import React, { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import React, { useState, useEffect, useCallback } from 'react';
+// import { useParams } from 'react-router-dom';
 
-const Timer = () => {
-  const [seconds, setSeconds] = useState(60);
-
+const Timer = ({viewCurr, seconds, setSeconds, handleNextBtn}) => {
   useEffect(() => {
     // Update the timer every second
     const interval = setInterval(() => {
-      setSeconds(prevSeconds => (prevSeconds > 0 ? prevSeconds - 1 : 0));
+      if (viewCurr) {
+        setSeconds(prevSeconds => (prevSeconds > 0 ? prevSeconds - 1 : 0));
+      }
     }, 1000);
 
     // Cleanup the interval when the component unmounts
     return () => clearInterval(interval);
-  }, []); // Empty dependency array ensures the effect runs only once on mount
+  }, [viewCurr, setSeconds]); // Empty dependency array ensures the effect runs only once on mount
 
   const formatTime = (timeInSeconds) => {
     const minutes = Math.floor(timeInSeconds / 60);
     const remainingSeconds = timeInSeconds % 60;
     return `${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
   };
+
+  useEffect(() => {
+    if (seconds <= 0) {
+      handleNextBtn();
+    }
+  }, [seconds, viewCurr, handleNextBtn]);
 
   return (
     <div>
@@ -62,20 +68,26 @@ const Canvas = () => {
   );
 };
 
-function Voting({setViewCurr, setViewNext}) {
-    const { roomId } = useParams();
+function Voting({viewCurr, setViewCurr, setViewNext}) {
+    // const { roomId } = useParams();
     const [data, setData] = useState(["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine"]);
-     
-    function handleNextBtn() {
-      setViewCurr(false);
+    const [seconds, setSeconds] = useState(60);
+    /* FOR TESTING COMMENT OUT ABOVE LINE, UNCOMMENT BELOW LINE */
+    // const [seconds, setSeconds] = useState(10);
+ 
+    const handleNextBtn = useCallback(() => {
       setViewNext(true);
-    }
+      setViewCurr(false);
+      setSeconds(60);
+      /* FOR TESTING COMMENT OUT ABOVE LINE, UNCOMMENT BELOW LINE */
+      // setSeconds(10);
+    }, [setViewCurr, setViewNext, setSeconds]);
 
     return (
       <div className="background custom-text">
         
           <div className= "flex justify-end">
-            <Timer />
+            <Timer viewCurr={viewCurr} seconds={seconds} setSeconds={setSeconds} handleNextBtn={handleNextBtn} />
           </div>
         
           <div className="w-full mx-auto flex flex-row items-center">

--- a/src/__tests__/Timer.test.js
+++ b/src/__tests__/Timer.test.js
@@ -1,0 +1,115 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import App from "../App.js";
+import "setimmediate";
+
+test("loads home page", async () => {
+    render(<App />);
+
+    // starts at home page
+    expect(screen.getByText("Fictionary"));
+    expect(screen.getByText("Create a Room"));
+    await userEvent.click(screen.getByText("Create a Room"));
+});
+
+test("loads create a room page", async () => {
+    render(<App />);
+    
+    // create a room page (host page)
+    expect(screen.getByText("Enter Your Name (Host):")); 
+    const inputElement = document.getElementById("name");
+    await userEvent.type(inputElement, "myUsername");
+    await userEvent.click(screen.getByText("Enter"));
+    // line above causes terminal to show "errors" but these are warnings in react that don't cause any bugs
+});
+
+test("loads lobby page", async () => {
+    render(<App />);
+    
+    // testing Lobby.js component
+    expect(screen.getByText("Lobby"));
+    await userEvent.click(screen.getByText("Start"));
+});
+
+test("loads timer in categories page", async () => {
+    render(<App />);
+    await userEvent.click(screen.getByText("Start"));
+
+    // testing timer in Categories.js component
+    expect(screen.getByText("1:00"));
+    expect(screen.getByText("Vote for a Category"));
+    await userEvent.click(screen.getByText("(this should not be visible)"));
+});
+
+test("loads timer in drawing page", async () => {
+    render(<App />);
+    await userEvent.click(screen.getByText("Start"));
+    await userEvent.click(screen.getByText("(this should not be visible)"));
+
+    // testing timer in Drawing.js component
+    expect(screen.getByText("3:00"));
+    expect(screen.getByText("Drawing Tools"));
+    await userEvent.click(screen.getByText("Submit Drawing"));
+});
+
+test("loads timer in voting page", async () => {
+    render(<App />);
+    await userEvent.click(screen.getByText("Start"));
+    await userEvent.click(screen.getByText("(this should not be visible)"));
+    await userEvent.click(screen.getByText("Submit Drawing"));
+
+    // testing timer in Voting.js component
+    expect(screen.getByText("01:00"));
+    expect(screen.getByText("CATEGORY IS"));
+    await userEvent.click(screen.getByText("Submit"));
+});
+
+test("reloads timer in categories page", async () => {
+    render(<App />);
+    await userEvent.click(screen.getByText("Start"));
+    await userEvent.click(screen.getByText("(this should not be visible)"));
+    await userEvent.click(screen.getByText("Submit Drawing"));
+    await userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByTestId("results-ctn-btn"));
+    await userEvent.click(screen.getByTestId("scoreboard-ctn-btn"));
+
+    // testing timer again in categories
+    expect(screen.getByText("1:00"));
+    expect(screen.getByText("Vote for a Category"));
+    await userEvent.click(screen.getByText("(this should not be visible)"));
+});
+
+test("reloads timer in drawing page", async () => {
+    render(<App />);
+    await userEvent.click(screen.getByText("Start"));
+    await userEvent.click(screen.getByText("(this should not be visible)"));
+    await userEvent.click(screen.getByText("Submit Drawing"));
+    await userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByTestId("results-ctn-btn"));
+    await userEvent.click(screen.getByTestId("scoreboard-ctn-btn"));
+    await userEvent.click(screen.getByText("(this should not be visible)"));
+
+    // testing timer again in drawing
+    expect(screen.getByText("3:00"));
+    expect(screen.getByText("Drawing Tools"));
+    await userEvent.click(screen.getByText("Submit Drawing"));
+});
+
+test("reloads timer in voting page", async () => {
+    render(<App />);
+    await userEvent.click(screen.getByText("Start"));
+    await userEvent.click(screen.getByText("(this should not be visible)"));
+    await userEvent.click(screen.getByText("Submit Drawing"));
+    await userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByTestId("results-ctn-btn"));
+    await userEvent.click(screen.getByTestId("scoreboard-ctn-btn"));
+    await userEvent.click(screen.getByText("(this should not be visible)"));
+    await userEvent.click(screen.getByText("Submit Drawing"));
+
+    // testing timer again in voting
+    expect(screen.getByText("01:00"));
+    expect(screen.getByText("CATEGORY IS"));
+    await userEvent.click(screen.getByText("Submit"));
+});


### PR DESCRIPTION
### Fix: timer
This pull request is to fix the bug where the game states/pages that involve a timer/counter (Categories.js, Drawing.js, and Voting.js) do not correctly parse the amount of time that has elapsed.

Since we have also attached the timers as a condition for moving onto the next game state/page, the broken timer mechanics have also caused a glitch where two game state/pages will render at the same time. The game state/page with a broken timer will render below the current game state/page.

**TL;DR: So that the flow of the game is maintained, I have modified and refactored some of the code while adding in my own implementations to fix the timer mechanics in Categories.js, Drawing.js, and Voting.js**

### The steps taken in my commits:
* modify the useEffect blocks that decrement the timers to only decrement when the component is rendered
* modify the function that triggers to go to the next game state/page to reset the timer
* create test cases for testing that the timers correctly parse when loading the /room URL page and correctly reset their timers when the components are re-rendered onto the screen (file is named Timer.test.js since Room.test.js is already used for testing the general flow of the game with dynamic rendering)
* created handleNext() function in Lobby.js to handle triggering the code for rendering in the handleStartClick() function; this separates the rendering logic from the websocket logic so it’s easier for others to modify the websocket logic without affecting the rendering

### Code written by others that are affected:
* Modified timer code in Categories.js and Drawing.js written by @StellarSparks 
* Modified timer code in Voting.js written by @jasminebroton 

Addresses #21

