### PR TITLE
Fix: Fixed the ArtArray to show when page loads.

### DIFF
--- a/src/Rules.js
+++ b/src/Rules.js
@@ -17,7 +17,7 @@ function Rules(){
     const ArtArray = [Cat_Select, Art_Drawing, Trick_Vote, Scoring];
     const [activeRule, setActiveRule,] = useState(0);
     const [isVisible, setIsVisible] = useState(true);
-    const [isPictureVisible, setIsPictureVisible] = useState(true);
+    const [isPictureVisible, setIsPictureVisible] = useState(false);
 
 
     function handleClick() {


### PR DESCRIPTION
This fix is to have the art array images not show up when the Rules page loads as there is no image for the first rule.

1. Updated isPictureVisible and setIsPictureVisible in Rules.js to be set as false so that it doesn't show when the page loads.

Addresses #70 